### PR TITLE
Feature/dicece loss with ignore label and weights

### DIFF
--- a/nnunet/training/loss_functions/dice_loss.py
+++ b/nnunet/training/loss_functions/dice_loss.py
@@ -322,8 +322,7 @@ class DC_and_CE_loss(nn.Module):
         self.weight_dice = weight_dice
         self.weight_ce = weight_ce
         self.aggregate = aggregate
-        self.ce = RobustCrossEntropyLoss(**ce_kwargs)
-        self.ce = RobustCrossEntropyLoss(ignore_index=ignore_label if ignore_label else -100, **ce_kwargs)
+        self.ce = RobustCrossEntropyLoss(ignore_index=ignore_label if ignore_label is not None else -100, **ce_kwargs)
 
         self.ignore_label = ignore_label
 

--- a/nnunet/training/loss_functions/dice_loss.py
+++ b/nnunet/training/loss_functions/dice_loss.py
@@ -323,7 +323,7 @@ class DC_and_CE_loss(nn.Module):
         self.weight_ce = weight_ce
         self.aggregate = aggregate
         self.ce = RobustCrossEntropyLoss(**ce_kwargs)
-        self.ce = RobustCrossEntropyLoss(ignore_index=ignore_label, **ce_kwargs)
+        self.ce = RobustCrossEntropyLoss(ignore_index=ignore_label if ignore_label else -100, **ce_kwargs)
 
         self.ignore_label = ignore_label
 

--- a/nnunet/training/network_training/nnUNet_variants/loss_function/nnUNetTrainerV2_Loss_CEandDice_Weighted.py
+++ b/nnunet/training/network_training/nnUNet_variants/loss_function/nnUNetTrainerV2_Loss_CEandDice_Weighted.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-
+from pprint import pprint
 
 from nnunet.training.loss_functions.dice_loss import DCandCEWeightedLoss
 from nnunet.training.network_training.nnUNetTrainerV2 import nnUNetTrainerV2
@@ -23,6 +23,7 @@ class nnUNetTrainer_V2_Loss_CEandDice_Weighted(nnUNetTrainerV2):
         super().__init__(plans_file, fold, output_folder, dataset_directory, batch_dice, stage, unpack_data,
                          deterministic, fp16)
         self.loss = DCandCEWeightedLoss(
+            ignore_label=kwargs.get('ignore_label', None),
             class_weights=kwargs.get('class_weights', []),
             weight_dc=kwargs.get('weight_dc', 1),
             weight_ce=kwargs.get('weight_ce', 1),
@@ -30,3 +31,4 @@ class nnUNetTrainer_V2_Loss_CEandDice_Weighted(nnUNetTrainerV2):
                                                              'do_bg': False}),
             ce_kwargs=kwargs.get("ce_kwargs", {})
         )
+        print(f"Using DCandCEWeightedLoss with the following parameters:\n {pprint(kwargs)}")


### PR DESCRIPTION
- Added an ignore_label parameter to the weighted dice and cross entropy loss.
- Moved the ignore_label for RobustCrossEntropyLoss to ignore_index, since ignore_label was not computing the mean afterwards (different behaviour when using ignore_label, e.g. loss was 160 and overruled the dice loss)